### PR TITLE
Removed toast message when purchasing cows

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -60,10 +60,7 @@ export default function PlayPage() {
     );
   // Stryker restore all 
 
-
-  const onSuccessBuy = () => {
-    toast(`Cow bought!`);
-  }
+  const onSuccessBuy = () => {}
 
   // Stryker disable all (can't check if commonsId is null because it is mocked)
   const objectToAxiosParamsBuy = (newUserCommons) => ({

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -89,8 +89,6 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
 
-        expect(mockToast).toBeCalledWith("Cow bought!");
-
         const sellCowButton = screen.getByTestId("sell-cow-button");
         fireEvent.click(sellCowButton);
 


### PR DESCRIPTION
## Overview
In this pr, I removed the toast message when purchasing cows.

## Localhost Demonstration
![ezgif com-video-to-gif](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/fdef0b31-0724-437f-8c20-6acb453c5a7f)

## Screenshot of test coverage and mutation coverage
<img width="891" alt="Screenshot 2023-08-15 at 8 42 43 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/33535348-3890-4c91-b369-ce47a14b38f3">
<img width="876" alt="Screenshot 2023-08-15 at 8 44 02 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/1c2966c2-7d9e-4b61-9f7e-d1a05a7b9f0a">

## Issue Link
Closes #5 