### PR TITLE
Trivial changes to optimize the workflow

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -24,7 +24,7 @@ jobs:
           timezoneLinux: "America/Los_Angeles"
       - uses: actions/checkout@v3.5.2
         with: 
-          fetch-depth: 2
+          fetch-depth: 1
 
       - name: Get PR number
         id: get-pr-num

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 80
 
     steps:
       - uses: szenius/set-timezone@v1.2


### PR DESCRIPTION
## Overview
In this pr, I modify the workflow file to avoid potential timeout issues. 

1. For pr mutation maybe we can just fetch the latest commit, assume we will make small pr for this project.
2. For main mutation I doubled the check time to avoid timeout

Closes #18 