### PR TITLE
[Andrew] Format Leaderboard Wealth to Currency

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -14,8 +14,9 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             accessor: 'username', 
         },
         {
+            id : 'totalWealth',
             Header: 'Total Wealth',
-            accessor: 'totalWealth',
+            accessor: (leaderboard) => `$${String(leaderboard.totalWealth.toFixed(2))}`,
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -82,14 +82,14 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1000.00");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsSold`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowDeaths`)).toHaveTextContent("5");


### PR DESCRIPTION
## Overview
In this pull request, I formatted the Leaderboard Wealth column values to display as USD with 2 decimal places. 

<img width="1216" alt="Screenshot 2023-08-17 at 2 51 16 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/33c38fc0-c0a2-4586-a690-85a19cb4ceb7">

## Tests

- [x] `npm test`
- [x] `npm run coverage`
- [x] `npm stryker npx stryker run -m src/main/components/Leaderboard/LeaderboardTable.js`

<img width="706" alt="Screenshot 2023-08-17 at 2 59 38 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/e7919ae2-54a5-4c24-8e4c-c5b4645ef310">
<img width="703" alt="Screenshot 2023-08-17 at 3 00 48 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/32d42b6b-15f3-46ad-9187-8deccfb0946c">
<img width="778" alt="Screenshot 2023-08-17 at 3 02 47 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/f2422222-72e6-4803-96a9-73b991fca75f">

Closes #4 