### PR TITLE
[Andrew] Narrow Create Commons Form UI

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -1,208 +1,234 @@
-import {Button, Form} from "react-bootstrap";
-import {useForm} from "react-hook-form";
-import {useBackend} from "main/utils/useBackend";
+import { Button, Form, Row, Col } from 'react-bootstrap';
+import { useForm } from "react-hook-form";
+import { useBackend } from "main/utils/useBackend";
 
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
 
-function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
-  // Stryker disable all
-  const {
-    register,
-    formState: {errors},
-    handleSubmit,
-  } = useForm(
-    {defaultValues: initialCommons || {}}
-  );
-  // Stryker restore all
+function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialCommons || {} }
+    );
+    // Stryker restore all
 
-  const {data: healthUpdateStrategies} = useBackend(
-    "/api/commons/all-health-update-strategies", {
-      method: "GET",
-      url: "/api/commons/all-health-update-strategies",
+    const { data: healthUpdateStrategies } = useBackend(
+        "/api/commons/all-health-update-strategies", {
+        method: "GET",
+        url: "/api/commons/all-health-update-strategies",
     },
-  );
+    );
 
-  const testid = "CommonsForm";
+    const testid = "CommonsForm";
 
-  const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;
-  const aboveStrategy = initialCommons?.aboveCapacityStrategy || healthUpdateStrategies?.defaultAboveCapacity;
-  
-  return (
-    <Form onSubmit={handleSubmit(submitAction)}>
-      {initialCommons && (
-        <Form.Group className="mb-3">
-          <Form.Label htmlFor="id">Id</Form.Label>
-          <Form.Control
-            data-testid={`${testid}-id`}
-            id="id"
-            type="text"
-            {...register("id")}
-            value={initialCommons.id}
-            disabled
-          />
-        </Form.Group>
-      )}
+    const belowStrategy = initialCommons?.belowCapacityStrategy || healthUpdateStrategies?.defaultBelowCapacity;
+    const aboveStrategy = initialCommons?.aboveCapacityStrategy || healthUpdateStrategies?.defaultAboveCapacity;
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="name">Commons Name</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-name`}
-          id="name"
-          type="text"
-          isInvalid={!!errors.name}
-          {...register("name", {required: "Commons name is required"})}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.name?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+            <Row>                
+                {initialCommons && (
+                    <Form.Group className="mb-3">
+                        <Form.Label htmlFor="id">Id</Form.Label>
+                        <Form.Control
+                            data-testid={`${testid}-id`}
+                            id="id"
+                            type="text"
+                            {...register("id")}
+                            value={initialCommons.id}
+                            disabled
+                        />
+                    </Form.Group>
+                )}
+                <Col>
+                    <Form.Group className="mb-3">
+                        <Form.Label htmlFor="name">Commons Name</Form.Label>
+                        <Form.Control
+                            data-testid={`${testid}-name`}
+                            id="name"
+                            type="text"
+                            isInvalid={!!errors.name}
+                            {...register("name", { required: "Commons name is required" })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.name?.message}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
-        <Form.Control
-          id="startingBalance"
-          data-testid={`${testid}-startingBalance`}
-          type="number"
-          step="0.01"
-          isInvalid={!!errors.startingBalance}
-          {...register("startingBalance", {
-            valueAsNumber: true,
-            required: "Starting Balance is required",
-            min: {value: 0.00, message: "Starting Balance must be ≥ 0.00"},
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.startingBalance?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="startingBalance">Starting Balance</Form.Label>
+                    <Form.Control
+                        id="startingBalance"
+                        data-testid={`${testid}-startingBalance`}
+                        type="number"
+                        step="0.01"
+                        isInvalid={!!errors.startingBalance}
+                        {...register("startingBalance", {
+                            valueAsNumber: true,
+                            required: "Starting Balance is required",
+                            min: { value: 0.00, message: "Starting Balance must be ≥ 0.00" },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.startingBalance?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="cowPrice">Cow Price</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-cowPrice`}
+                        id="cowPrice"
+                        type="number"
+                        step="0.01"
+                        isInvalid={!!errors.cowPrice}
+                        {...register("cowPrice", {
+                            valueAsNumber: true,
+                            required: "Cow price is required",
+                            min: { value: 0.01, message: "Cow price must be ≥ 0.01" },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.cowPrice?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="milkPrice">Milk Price</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-milkPrice`}
+                        id="milkPrice"
+                        type="number"
+                        step="0.01"
+                        isInvalid={!!errors.milkPrice}
+                        {...register("milkPrice", {
+                            valueAsNumber: true,
+                            required: "Milk price is required",
+                            min: { value: 0.01, message: "Milk price must be ≥ 0.01" },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.milkPrice?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="cowPrice">Cow Price</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-cowPrice`}
-          id="cowPrice"
-          type="number"
-          step="0.01"
-          isInvalid={!!errors.cowPrice}
-          {...register("cowPrice", {
-            valueAsNumber: true,
-            required: "Cow price is required",
-            min: {value: 0.01, message: "Cow price must be ≥ 0.01"},
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.cowPrice?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="startingDate">Starting Date</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-startingDate`}
+                        id="startingDate"
+                        type="date"
+                        isInvalid={!!errors.startingDate}
+                        {...register("startingDate", {
+                            valueAsDate: true,
+                            validate: {
+                                isPresent: (v) => !isNaN(v) || "Starting date is required",
+                            },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.startingDate?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="degradationRate">Degradation Rate</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-degradationRate`}
+                        id="degradationRate"
+                        type="number"
+                        step="0.01"
+                        isInvalid={!!errors.degradationRate}
+                        {...register("degradationRate", {
+                            valueAsNumber: true,
+                            required: "Degradation rate is required",
+                            min: { value: 0.00, message: "Degradation rate must be ≥ 0.00" },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.degradationRate?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>    
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="carryingCapacity">Carrying Capacity</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-carryingCapacity`}
+                        id="carryingCapacity"
+                        type="number"
+                        step="1"
+                        isInvalid={!!errors.carryingCapacity}
+                        {...register("carryingCapacity", {
+                            valueAsNumber: true,
+                            required: "Carrying capacity is required",
+                            min: { value: 1, message: "Carrying Capacity must be ≥ 1" },
+                        })}
+                    />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.carryingCapacity?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="milkPrice">Milk Price</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-milkPrice`}
-          id="milkPrice"
-          type="number"
-          step="0.01"
-          isInvalid={!!errors.milkPrice}
-          {...register("milkPrice", {
-            valueAsNumber: true,
-            required: "Milk price is required",
-            min: {value: 0.01, message: "Milk price must be ≥ 0.01"},
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.milkPrice?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="startingDate">Starting Date</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-startingDate`}
-          id="startingDate"
-          type="date"
-          isInvalid={!!errors.startingDate}
-          {...register("startingDate", {
-            valueAsDate: true,
-            validate: {
-              isPresent: (v) => !isNaN(v) || "Starting date is required",
-            },
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.startingDate?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="degradationRate">Degradation Rate</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-degradationRate`}
-          id="degradationRate"
-          type="number"
-          step="0.01"
-          isInvalid={!!errors.degradationRate}
-          {...register("degradationRate", {
-            valueAsNumber: true,
-            required: "Degradation rate is required",
-            min: {value: 0.00, message: "Degradation rate must be ≥ 0.00"},
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.degradationRate?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="carryingCapacity">Carrying Capacity</Form.Label>
-        <Form.Control
-          data-testid={`${testid}-carryingCapacity`}
-          id="carryingCapacity"
-          type="number"
-          step="1"
-          isInvalid={!!errors.carryingCapacity}
-          {...register("carryingCapacity", {
-            valueAsNumber: true,
-            required: "Carrying capacity is required",
-            min: {value: 1, message: "Carrying Capacity must be ≥ 1"},
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.carryingCapacity?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <h4>
-        Health update formula
-      </h4>
-      <HealthUpdateStrategiesDropdown
-        formName={"aboveCapacityHealthUpdateStrategy"}
-        displayName={"When above capacity"}
-        initialValue={ aboveStrategy }
-        register={register}
-        healthUpdateStrategies={healthUpdateStrategies}
-      />
-      <HealthUpdateStrategiesDropdown
-        formName={"belowCapacityHealthUpdateStrategy"}
-        displayName={"When below capacity"}
-        initialValue={ belowStrategy }
-        register={register}
-        healthUpdateStrategies={healthUpdateStrategies}
-      />
+            <h4>
+                Health update formula
+            </h4>
+            <Row>
+                <Col>
+                    <HealthUpdateStrategiesDropdown
+                        formName={"aboveCapacityHealthUpdateStrategy"}
+                        displayName={"When above capacity"}
+                        initialValue={aboveStrategy}
+                        register={register}
+                        healthUpdateStrategies={healthUpdateStrategies}
+                    />           
+                </Col>
+                <Col>
+                    <HealthUpdateStrategiesDropdown
+                        formName={"belowCapacityHealthUpdateStrategy"}
+                        displayName={"When below capacity"}
+                        initialValue={belowStrategy}
+                        register={register}
+                        healthUpdateStrategies={healthUpdateStrategies}
+                    />
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
+                    <Form.Check
+                        data-testid={`${testid}-showLeaderboard`}
+                        type="checkbox"
+                        id="showLeaderboard"
+                        {...register("showLeaderboard")}
+                    />
+                    </Form.Group>
+                </Col>
+            </Row>
 
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="showLeaderboard">Show Leaderboard?</Form.Label>
-        <Form.Check
-          data-testid={`${testid}-showLeaderboard`}
-          type="checkbox"
-          id="showLeaderboard"
-          {...register("showLeaderboard")}
-        />
-      </Form.Group>
 
-      <Button type="submit" data-testid="CommonsForm-Submit-Button">{buttonLabel}</Button>
-    </Form>
-  );
+
+
+
+            <Button type="submit" data-testid="CommonsForm-Submit-Button">{buttonLabel}</Button>
+        </Form>
+    );
 }
 
 export default CommonsForm;


### PR DESCRIPTION
## Overview
In this pull request, I narrowed the fields of the Create Commons Form by combining them into single rows, which I think is a more accessible and visually coherent way to maintain a user-friendly form experience than fixed field widths. 

https://ucsb-cs156-m23.github.io/proj-happycows-m23-10am-3/prs/25/storybook/?path=/story/components-commons-commonsform--uncontrolled

<img width="818" alt="Screenshot 2023-08-17 at 3 41 43 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/8cbd7cf7-fe6c-4874-b2d3-a67c418f1a3b">

## Disclaimer
This pull request does not complete every aspect of the user story #1.  Default values and an organized object class will be added in a separate pull request.

## Tests

- [x] `npm test`
- [x] `npm run coverage`
- [x] `npm stryker npx stryker run -m src/main/components/Commons/CommonsForm.js`

Closes #27 and #28