### PR TITLE
added the capacityPerUser in entities and models for crating parameters

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -30,6 +30,7 @@ public class Commons {
     private boolean showLeaderboard;
 
     private int carryingCapacity;
+    private int capacityPerUser;
     private double degradationRate;
 
     // these defaults match old behavior

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -25,6 +25,8 @@ public class CreateCommonsParams {
     @NumberFormat
     private int carryingCapacity;
     @NumberFormat
+    private int capacityPerUser;
+    @NumberFormat
     private double degradationRate;
 
     private String aboveCapacityHealthUpdateStrategy;


### PR DESCRIPTION
## Overview
In this pull request, I added the capacityPerUser to the entity and the create params

## Tests

- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn clean test org.pitest:pitest-maven:mutationCoverage`

Working on #13 