### PR TITLE
Common stats endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -27,6 +27,8 @@ import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
@@ -59,6 +61,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+    @Autowired
+    CommonStatsJobFactory commonStatsJobFactory;
 
     @Operation(summary = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -141,5 +146,14 @@ public class JobsController extends ApiController {
 
         InstructorReportJobSingleCommons instructorReportJobSingleCommons = (InstructorReportJobSingleCommons) instructorReportJobSingleCommonsFactory.create(commonsId);
         return jobService.runAsJob(instructorReportJobSingleCommons);
+    }
+
+    @Operation(summary = "Launch Job to Save Common Stats")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/commonstats")
+    public Job commonStats(
+    ) { 
+        CommonStatsJob commonStatsJob = (CommonStatsJob) commonStatsJobFactory.create();
+        return jobService.runAsJob(commonStatsJob);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -47,8 +47,11 @@ import edu.ucsb.cs156.happiercows.jobs.InstructorReportJobSingleCommonsFactory;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -76,6 +79,9 @@ public class JobsControllerTests extends ControllerTestCase {
         UserCommonsRepository userCommonsRepository;
 
         @MockBean
+        CommonStatsRepository commonStatsRepository;
+
+        @MockBean
         UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
         @MockBean
@@ -89,6 +95,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
         @MockBean
         InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+        @MockBean
+        CommonStatsJobFactory commonStatsJobFactory;
 
         @WithMockUser(roles = { "ADMIN" })
         @Test
@@ -305,6 +314,23 @@ public class JobsControllerTests extends ControllerTestCase {
                 // act
                 MvcResult response = mockMvc
                                 .perform(post("/api/jobs/launch/instructorreportsinglecommons?commonsId=1")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_common_stats_job() throws Exception {
+                // act
+                MvcResult response = mockMvc
+                                .perform(post("/api/jobs/launch/commonstats?commonsId=1")
                                                 .with(csrf()))
                                 .andExpect(status().isOk()).andReturn();
 


### PR DESCRIPTION
## Overview
For this pr, I created a common stats job endpoint in jobs controller and also its revelent tests for #12 

## Tests
- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn test org.pitest:pitest-maven:mutationCoverage`

Closes #34 