### PR TITLE
Common stats csv

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -2,26 +2,39 @@ package edu.ucsb.cs156.happiercows.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.util.Resource;
+
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.helpers.CommonStatsCSVHelper;
+import edu.ucsb.cs156.happiercows.helpers.ReportCSVHelper;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +50,9 @@ public class CommonsController extends ApiController {
 
     @Autowired
     private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private CommonStatsRepository commonStatsRepository;
 
     @Autowired
     ObjectMapper mapper;
@@ -269,4 +285,25 @@ public class CommonsController extends ApiController {
                 .totalUsers(numUsers.orElse(0))
                 .build();
     }
+
+    @Operation(summary="Download CSV file for common stats for a given Commons ID")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/{commonsId}/download")
+    public ResponseEntity<InputStreamResource> downloadCommonStats(
+            @Parameter(name = "commonsId") @RequestParam Long commonsId) throws IOException{
+
+        Iterable<CommonStats> commonStatsList = commonStatsRepository.findAllByCommonsId(commonsId);
+
+        String filename = String.format("commonStats%05d.csv",commonsId);
+
+        ByteArrayInputStream bais = CommonStatsCSVHelper.toCSV(commonStatsList);
+        InputStreamResource isr = new InputStreamResource(bais);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
+                .contentType(MediaType.parseMediaType("application/csv"))
+                .body(isr);
+    }
+
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -1,0 +1,68 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/*
+ * This code is based on 
+ * <a href="https://bezkoder.com/spring-boot-download-csv-file/">https://bezkoder.com/spring-boot-download-csv-file/</a>
+ * and provides a way to serve up a CSV file containing information associated
+ * with an instructor report.
+ */
+
+public class CommonStatsCSVHelper {
+
+  private CommonStatsCSVHelper() {}
+
+  /**
+   * This method is a hack to avoid a jacoco issue; it isn't possible to 
+   * exclude an individual method call from jacoco coverage, but we can
+   * exclude the entire method.  
+   * @param out
+   */
+
+  public static void flush_and_close_noPitest(ByteArrayOutputStream out, CSVPrinter csvPrinter) throws IOException {
+    csvPrinter.flush();
+    csvPrinter.close();
+    out.flush();
+    out.close();
+  }
+  
+  public static ByteArrayInputStream toCSV(Iterable<CommonStats> lines) throws IOException {
+    final CSVFormat format = CSVFormat.DEFAULT;
+
+    List<String> headers = Arrays.asList(
+        "id",
+        "commonsId",
+        "numCows",
+        "avgHealth",
+        "timestamp");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format);
+
+    csvPrinter.printRecord(headers);
+
+    for (CommonStats stats : lines) {
+      List<String> data = Arrays.asList(
+          String.valueOf(stats.getId()),
+          String.valueOf(stats.getCommonsId()),
+          String.valueOf(stats.getNumCows()),
+          String.valueOf(stats.getAvgHealth()),
+          String.valueOf(stats.getTimestamp()));
+      csvPrinter.printRecord(data);
+    }
+
+    flush_and_close_noPitest(out, csvPrinter);
+    return new ByteArrayInputStream(out.toByteArray());
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -24,10 +24,11 @@ public class CommonStatsCSVHelper {
   private CommonStatsCSVHelper() {}
 
   /**
-   * This method is a hack to avoid a jacoco issue; it isn't possible to 
-   * exclude an individual method call from jacoco coverage, but we can
-   * exclude the entire method.  
-   * @param out
+   * This method is a hack to avoid a pitest issue; it isn't possible to 
+   * exclude an individual method call from pitest coverage, but we can
+   * exclude the entire method by name in the pitest settings in pom.xml
+   * @param out stream to close
+   * @param csvPrinter printer to close
    */
 
   public static void flush_and_close_noPitest(ByteArrayOutputStream out, CSVPrinter csvPrinter) throws IOException {

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommonStatsRepository extends JpaRepository<CommonStats, Long> {
+    Iterable<CommonStats> findAllByCommonsId(Long commonsId);
     
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 
+@Service
 public class AverageCowHealthService {
 
     @Autowired


### PR DESCRIPTION
## Overview
For this pr, I added csv functionality for common stats to implement #12
I also add back the decorator I forgot to add at `AverageCowHealthService.java`

## Screenshot
<img width="1454" alt="Screenshot 2023-08-19 at 4 16 42 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/84555609/e920a523-fdcc-4675-b90a-980f38bd686c">

## Tests
- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn test org.pitest:pitest-maven:mutationCoverage`

Closes #36 