### PR TITLE
rh - edited POST operation and corresponding test cases for capacityPerUser field

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -153,7 +153,8 @@ public class CommonsController extends ApiController {
                 .startingDate(params.getStartingDate())
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
-                .carryingCapacity(params.getCarryingCapacity());
+                .carryingCapacity(params.getCarryingCapacity())
+                .capacityPerUser(params.getCapacityPerUser());
 
         // ok to set null values for these, so old backend still works
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -66,6 +66,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -79,6 +80,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -117,6 +119,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -128,6 +131,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         // don't include null values to simulate old frontend
@@ -167,6 +171,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -213,6 +219,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -223,6 +230,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);


### PR DESCRIPTION
## Overview
For this pr, I edited the post and corresponding test cases to accept the capacityPerUser field.
<img width="901" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/520f8f6e-55fe-4d1a-9f12-bde36e591b2f">
<img width="906" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/a6f15fc4-5d99-450f-a815-c9797ac1587c">

## Tests
- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn test org.pitest:pitest-maven:mutationCoverage`

Working towards #13 