### PR TITLE
[Andrew] Add capacityPerUser to Create + Edit pages

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -12,6 +12,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
         milkPrice: 20,
         degradationRate: 0.01,
         carryingCapacity: 1000,
+        capacityPerUser: 50,
       } 
     const {
         register,
@@ -177,6 +178,10 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                     </Form.Group>    
                 </Col>
                 <Col>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
                     <Form.Group className="mb-3">
                     <Form.Label htmlFor="carryingCapacity">Carrying Capacity</Form.Label>
                     <Form.Control
@@ -197,29 +202,26 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                     </Form.Control.Feedback>
                     </Form.Group>
                 </Col>
-            </Row>
-
-            <Row>
-                <h3>
-                Health update formula
-                </h3>
                 <Col>
-                    <HealthUpdateStrategiesDropdown
-                        formName={"aboveCapacityHealthUpdateStrategy"}
-                        displayName={"When above capacity"}
-                        initialValue={aboveStrategy}
-                        register={register}
-                        healthUpdateStrategies={healthUpdateStrategies}
-                    />           
-                </Col>
-                <Col>
-                    <HealthUpdateStrategiesDropdown
-                        formName={"belowCapacityHealthUpdateStrategy"}
-                        displayName={"When below capacity"}
-                        initialValue={belowStrategy}
-                        register={register}
-                        healthUpdateStrategies={healthUpdateStrategies}
+                    <Form.Group className="mb-3">
+                    <Form.Label htmlFor="capacityPerUser">Capacity Per User</Form.Label>
+                    <Form.Control
+                        data-testid={`${testid}-capacityPerUser`}
+                        id="capacityPerUser"
+                        type="number"
+                        step="1"
+                        defaultValue={defaultValues.capacityPerUser}
+                        isInvalid={!!errors.capacityPerUser}
+                        {...register("capacityPerUser", {
+                            valueAsNumber: true,
+                            required: "Capacity per user is required",
+                            min: { value: 1, message: "Capacity per user must be ≥ 1" },
+                        })}
                     />
+                    <Form.Control.Feedback type="invalid">
+                        {errors.capacityPerUser?.message}
+                    </Form.Control.Feedback>
+                    </Form.Group>
                 </Col>
                 <Col>
                     <Form.Group className="mb-3">
@@ -231,6 +233,32 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                         {...register("showLeaderboard")}
                     />
                     </Form.Group>
+                </Col>
+            </Row>
+
+            <Row>
+                <h4>
+                Health Update Formula
+                </h4>
+                <Col>
+                    <HealthUpdateStrategiesDropdown
+                        formName={"aboveCapacityHealthUpdateStrategy"}
+                        displayName={"When Above Capacity"}
+                        initialValue={aboveStrategy}
+                        register={register}
+                        healthUpdateStrategies={healthUpdateStrategies}
+                    />           
+                </Col>
+                <Col>
+                    <HealthUpdateStrategiesDropdown
+                        formName={"belowCapacityHealthUpdateStrategy"}
+                        displayName={"When Below Capacity"}
+                        initialValue={belowStrategy}
+                        register={register}
+                        healthUpdateStrategies={healthUpdateStrategies}
+                    />
+                </Col>
+                <Col>
                 </Col>
             </Row>
 

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -36,6 +36,7 @@ export default function CommonsEditPage() {
         "startingDate": commons.startingDate,
         "degradationRate": commons.degradationRate,
         "carryingCapacity": commons.carryingCapacity,
+        "capacityPerUser": commons.capacityPerUser,
         "aboveCapacityHealthUpdateStrategy": commons.aboveCapacityHealthUpdateStrategy,
         "belowCapacityHealthUpdateStrategy": commons.belowCapacityHealthUpdateStrategy,
         "showLeaderboard": commons.showLeaderboard,

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -48,9 +48,10 @@ describe("CommonsForm tests", () => {
       /Starting Date/,
       /Degradation Rate/,
       /Carrying Capacity/,
+      /Capacity Per User/,
       /Show Leaderboard\?/,
-      /When below capacity/,
-      /When above capacity/,
+      /When Below Capacity/,
+      /When Above Capacity/,
 
     ].forEach(
       (pattern) => {
@@ -93,6 +94,8 @@ describe("CommonsForm tests", () => {
     fireEvent.change(degradationRateInput, { target: { value: "" } });
     const carryingCapacityInput = screen.getByTestId("CommonsForm-carryingCapacity");
     fireEvent.change(carryingCapacityInput, { target: { value: "" } });
+    const capacityPerUserInput = screen.getByTestId("CommonsForm-capacityPerUser");
+    fireEvent.change(capacityPerUserInput, { target: { value: "" } });
     fireEvent.click(submitButton);
 
     expect(await screen.findByTestId("CommonsForm-name")).toBeInTheDocument();
@@ -105,6 +108,7 @@ describe("CommonsForm tests", () => {
     expect(screen.getByText(/starting date is required/i)).toBeInTheDocument();
     expect(screen.getByText(/degradation rate is required/i)).toBeInTheDocument();
     expect(screen.getByText(/carrying capacity is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/capacity per user is required/i)).toBeInTheDocument();
 
     // check that each of the fields that has 
     // a validation error is marked as invalid
@@ -119,6 +123,7 @@ describe("CommonsForm tests", () => {
       "CommonsForm-startingDate",
       "CommonsForm-degradationRate",
       "CommonsForm-carryingCapacity",
+      "CommonsForm-capacityPerUser",
     ].forEach(
       (testid) => {
         const element = screen.getByTestId(testid);
@@ -183,6 +188,9 @@ describe("CommonsForm tests", () => {
     fireEvent.click(submitButton);
     await screen.findByText(/Carrying Capacity must be ≥ 1/i);
 
+    fireEvent.change(screen.getByTestId("CommonsForm-capacityPerUser"), { target: { value: "-1" } });
+    fireEvent.click(submitButton);
+    await screen.findByText(/Capacity Per User must be ≥ 1/i);
 
     expect(submitAction).not.toBeCalled();
   });
@@ -228,7 +236,7 @@ describe("CommonsForm tests", () => {
       </QueryClientProvider>
     );
 
-    expect(await screen.findByText(/When below capacity/)).toBeInTheDocument();
+    expect(await screen.findByText(/When Below Capacity/)).toBeInTheDocument();
 
     expect(screen.getByTestId("aboveCapacityHealthUpdateStrategy-Linear")).toBeInTheDocument();
     expect(screen.getByTestId("aboveCapacityHealthUpdateStrategy-Linear")).toHaveAttribute("selected");

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -87,8 +87,9 @@ describe("AdminCreateCommonsPage tests", () => {
         const startDateField = screen.getByLabelText("Starting Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
         const carryingCapacityField = screen.getByLabelText("Carrying Capacity");
-        const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When above capacity");
-        const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When below capacity");
+        const capacityPerUserField = screen.getByLabelText("Capacity Per User");
+        const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When Above Capacity");
+        const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When Below Capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
         const button = screen.getByTestId("CommonsForm-Submit-Button");
 
@@ -99,6 +100,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(startDateField, { target: { value: "2023-08-20" } })
         fireEvent.change(degradationRateField, { target: { value: '30.4' } })
         fireEvent.change(carryingCapacityField, { target: { value: '25' } })
+        fireEvent.change(capacityPerUserField, { target: { value: '5' } })
         fireEvent.change(showLeaderboardField, { target: { value: true } })
 
         fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: {value: 'strat2' } })
@@ -119,6 +121,7 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: "2023-08-20T00:00:00.000Z", // [1]
             degradationRate: 30.4,
             carryingCapacity: 25,
+            capacityPerUser: 5,
             showLeaderboard: false,
             aboveCapacityHealthUpdateStrategy: "strat2",
             belowCapacityHealthUpdateStrategy: "strat3",

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -51,6 +51,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 10,
                 "degradationRate": 20.3,
                 "carryingCapacity": 100,
+                "capacityPerUser": 10,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat1",
                 "belowCapacityHealthUpdateStrategy": "strat2"
@@ -64,6 +65,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 5,
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 20,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3"
@@ -99,8 +101,9 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
-            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
-            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
+            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When Above Capacity/);
+            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When Below Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -110,6 +113,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(10);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -133,8 +137,9 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
-            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
-            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
+            const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When Above Capacity/);
+            const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When Below Capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
 
             expect(nameField).toHaveValue("Seths Common");
@@ -144,6 +149,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(10);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -159,6 +165,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(milkPriceField, { target: { value: 5 } })
             fireEvent.change(degradationRateField, { target: { value: 40.3 } })
             fireEvent.change(carryingCapacityField, { target: { value: 200 } })
+            fireEvent.change(capacityPerUserField, { target: { value: 20 } })
             fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: { value: "strat2" } })
             fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: { value: "strat3" } })
             fireEvent.click(showLeaderboardField)
@@ -179,6 +186,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 20,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3",
                 "showLeaderboard": true,


### PR DESCRIPTION
## Overview
In this pull request, I added the capacityPerUser field to the AdminCreateCommons and AdminEditCommons pages. This is linked to Ryan's capacityPerUser backend PRs #26 #38 #40.

<img width="1403" alt="Screenshot 2023-08-24 at 3 17 14 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/e669d6d0-b53c-44ef-8c6b-a44a8d5ad840">
<img width="1403" alt="Screenshot 2023-08-24 at 3 17 30 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/ff2df4d9-539a-44d5-b84b-1486e95215ae">

## Tests

- [x] `npm test`
- [x] `npm run coverage`
- [x] `npx stryker run -m src/main/components/Commons/CommonsForm.js`
- [x] `npx stryker run -m src/main/pages/AdminCreateCommonsPage.js` 
- [x] `npx stryker run -m src/main/pages/AdminEditCommonsPage.js` 

This PR closes #45.