### PR TITLE
update cow health equation using effective capacity instead of carrying capacity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -48,7 +48,7 @@ public class CommonsController extends ApiController {
     public ResponseEntity<String> getCommons() throws JsonProcessingException {
         log.info("getCommons()...");
         Iterable<Commons> commons = commonsRepository.findAll();
-        commons.forEach((common) -> getEffectiveCapacity(common));
+        commons.forEach((common) -> updateEffectiveCapacity(common));
         String body = mapper.writeValueAsString(commons);
         return ResponseEntity.ok().body(body);
     }
@@ -63,7 +63,7 @@ public class CommonsController extends ApiController {
         // below
         List<Commons> commonsList = new ArrayList<Commons>();
         commonsListIter.forEach(commonsList::add);
-        commonsList.forEach((common) -> getEffectiveCapacity(common));
+        commonsList.forEach((common) -> updateEffectiveCapacity(common));
 
         List<CommonsPlus> commonsPlusList1 = commonsList.stream()
                 .map(c -> toCommonsPlus(c))
@@ -82,7 +82,7 @@ public class CommonsController extends ApiController {
             @Parameter(name="id") @RequestParam long id) throws JsonProcessingException {
         Commons common = commonsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
-        common = getEffectiveCapacity(common);
+        common = updateEffectiveCapacity(common);
         CommonsPlus commonsPlus = toCommonsPlus(common);
 
         return commonsPlus;
@@ -141,7 +141,7 @@ public class CommonsController extends ApiController {
 
         Commons commons = commonsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Commons.class, id));
-        commons = getEffectiveCapacity(commons);
+        commons = updateEffectiveCapacity(commons);
         return commons;
     }
 
@@ -278,7 +278,7 @@ public class CommonsController extends ApiController {
                 .build();
     }
 
-    public Commons getEffectiveCapacity(Commons c) {
+    public Commons updateEffectiveCapacity(Commons c) {
         Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
         c.setEffectiveCapacity(Math.max(numUsers.orElse(0) * c.getCapacityPerUser(), c.getCarryingCapacity()));
         return c;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -312,7 +312,9 @@ public class CommonsController extends ApiController {
                 .totalUsers(numUsers.orElse(0))
                 .build();
     }
-
+    /** This method should be called each time a commons object is being used before the value of effective capacity is retrieved from that commons.  
+    This probably should go in the getter for effectiveCapacity, but we don't have access there to the commonsRepository to do the lookup of numUsers.
+   */
     public Commons updateEffectiveCapacity(Commons c) {
         Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
         c.setEffectiveCapacity(Math.max(numUsers.orElse(0) * c.getCapacityPerUser(), c.getCarryingCapacity()));

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -110,6 +110,7 @@ public class CommonsController extends ApiController {
         updated.setShowLeaderboard(params.getShowLeaderboard());
         updated.setDegradationRate(params.getDegradationRate());
         updated.setCarryingCapacity(params.getCarryingCapacity());
+        updated.setCapacityPerUser(params.getCapacityPerUser());
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {
             updated.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getAboveCapacityHealthUpdateStrategy()));
         }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -153,7 +153,8 @@ public class CommonsController extends ApiController {
                 .startingDate(params.getStartingDate())
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
-                .carryingCapacity(params.getCarryingCapacity());
+                .carryingCapacity(params.getCarryingCapacity())
+                .capacityPerUser(params.getCapacityPerUser());
 
         // ok to set null values for these, so old backend still works
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -30,6 +30,7 @@ public class Commons {
     private boolean showLeaderboard;
 
     private int carryingCapacity;
+    private int capacityPerUser;
     private double degradationRate;
 
     // these defaults match old behavior

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.lang.Math;
 
 @Data
 @AllArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -3,14 +3,17 @@ package edu.ucsb.cs156.happiercows.entities;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.lang.Math;
 
 @Data
 @AllArgsConstructor
@@ -31,6 +34,7 @@ public class Commons {
 
     private int carryingCapacity;
     private int capacityPerUser;
+    private int effectiveCapacity;
     private double degradationRate;
 
     // these defaults match old behavior
@@ -40,7 +44,6 @@ public class Commons {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private CowHealthUpdateStrategies aboveCapacityHealthUpdateStrategy = CowHealthUpdateStrategies.DEFAULT_ABOVE_CAPACITY;
-
 
     @OneToMany(mappedBy = "commons", cascade = CascadeType.REMOVE)
     @JsonIgnore

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -12,7 +12,6 @@ import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategy;
 
 import java.util.Optional;
 
-import edu.ucsb.cs156.happiercows.controllers.CommonsController;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategy;
 
 import java.util.Optional;
+import java.lang.Math;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -25,6 +25,8 @@ public class CreateCommonsParams {
     @NumberFormat
     private int carryingCapacity;
     @NumberFormat
+    private int capacityPerUser;
+    @NumberFormat
     private double degradationRate;
 
     private String aboveCapacityHealthUpdateStrategy;

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -19,13 +19,13 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
     Linear("Linear", "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            return user.getCowHealth() - (totalCows - commons.getCarryingCapacity()) * commons.getDegradationRate();
+            return user.getCowHealth() - (totalCows - commons.getEffectiveCapacity()) * commons.getDegradationRate();
         }
     },
     Constant("Constant", "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            if (totalCows <= commons.getCarryingCapacity()) {
+            if (totalCows <= commons.getEffectiveCapacity()) {
                 return user.getCowHealth() + commons.getDegradationRate();
             } else {
                 return user.getCowHealth() - commons.getDegradationRate();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -281,6 +281,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -294,6 +295,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -320,6 +322,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setShowLeaderboard(parameters.getShowLeaderboard());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(100);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
         parameters.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name());
         commons.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
         parameters.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop.name());
@@ -357,6 +361,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         Commons commons = Commons.builder()
@@ -368,6 +373,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -409,6 +415,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         Commons commons = Commons.builder()
@@ -420,6 +427,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -442,6 +450,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setDegradationRate(parameters.getDegradationRate());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(100);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
 
         requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -475,6 +485,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         Commons commons = Commons.builder()
@@ -486,6 +497,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -66,6 +66,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -79,6 +80,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -117,6 +119,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -128,6 +131,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         // don't include null values to simulate old frontend
@@ -167,6 +171,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -213,6 +219,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -223,6 +230,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(50)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -107,7 +107,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 9.0
                                 Cow health has been updated!""";
@@ -125,7 +125,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 Cow health has been updated!""";
@@ -133,7 +133,7 @@ public class UpdateCowHealthJobTests {
         }
 
         @Test
-        void test_uses_below_capacity_update_strategy_if_equal_to_carrying_capacity() throws Exception {
+        void test_uses_below_capacity_update_strategy_if_equal_to_effective_capacity() throws Exception {
                 commons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant);
                 double expectedNewHealth = 11.0;
 
@@ -144,7 +144,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 Cow health has been updated!""";
@@ -199,7 +199,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 User: Chris Gaucho, numCows: 6, cowHealth: 20.0
@@ -279,7 +279,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 5, cowHealth: -1.0
                                  5 cows for this user died.
                                  old cow health: -1.0, new cow health: 100.0
@@ -304,7 +304,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 No users in this commons, skipping
                                 Cow health has been updated!""";
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
@@ -20,6 +20,7 @@ class CowHealthUpdateStrategyTests {
     Commons commons = Commons.builder()
             .degradationRate(0.01)
             .carryingCapacity(100)
+            .effectiveCapacity(100)
             .build();
     UserCommons user = UserCommons.builder().cowHealth(50).build();
 


### PR DESCRIPTION
## Overview

In this pr - I updated the cowHealthUpdate to use effectiveCapacity instead of carryingCapacity

Using effective capacity from capacityPerUser * numUsers
<img width="827" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/f6304b77-9174-479e-952a-7d2a705de5dd">

Using effective capacity from carryingCapacity
<img width="810" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/c6340eb3-7122-4085-bf89-3bb305c2d824">

## Tests run
- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn test org.pitest:pitest-maven:mutationCoverage`

Working toward #13 

