### PR TITLE
add leaderboard back button

### DIFF
--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -10,11 +10,15 @@ import { useBackend } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.png";
 
+import { Button} from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+
 
 export default function LeaderboardPage() {
 
   const { commonsId } = useParams();
   const { data: currentUser } = useCurrentUser();
+  const navigate = useNavigate();
 
   // Stryker disable all 
   const { data: userCommons, error: _error, status: _status } =
@@ -50,6 +54,12 @@ export default function LeaderboardPage() {
   return (
     <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
         <BasicLayout>
+            <Button
+                onClick={() => navigate(-1)}
+                data-testid={"LeaderboardPage-back-button"}
+            >
+                Back
+            </Button>
             <div className="pt-2">
                 <h1>Leaderboard</h1>
                 {

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor, render } from "@testing-library/react";
+import { fireEvent, screen, waitFor, render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -11,6 +11,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
+    
     const originalModule = jest.requireActual('react-toastify');
     return {
         __esModule: true,
@@ -49,6 +50,23 @@ describe("LeaderboardPage tests", () => {
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
+
+    test("that navigate(-1) is called when Back is clicked", async () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`LeaderboardPage-back-button`)).toBeInTheDocument();
+        const backButton = screen.getByTestId(`LeaderboardPage-back-button`);
+
+        fireEvent.click(backButton);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(-1));
+    });
 
     test("renders without crashing for users", async () => {
         setupUser();


### PR DESCRIPTION
## Overview
In this pr, I added back button to leaderboard.

## Localhost Demonstration
![ezgif com-video-to-gif (1)](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/952ee1dd-f7ec-4baf-b6cf-0af980580458)

## Screenshot of test coverage and mutation coverage
<img width="810" alt="Screenshot 2023-08-24 at 7 09 21 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/e089c137-dcfd-4c73-8118-6762cef0b3fe">
<img width="811" alt="Screenshot 2023-08-24 at 7 09 04 PM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/93456493/980ce177-fd93-416b-b02b-1eadbeeed04d">

## Issue Link
Closes #9 