### PR TITLE
Added a modal popup when a user tries to delete a commons

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -41,7 +41,7 @@ export default function CommonsTable({ commons, currentUser }) {
     const commonsTableModal = (
     <Modal data-testid="CommonsTable-Modal" show={show} onHide={handleClose}>
         <Modal.Header closeButton>
-            <Modal.Title>Commons Deletion Warning! </Modal.Title>
+            <Modal.Title>Warning! You are about to delete a Commons! </Modal.Title>
         </Modal.Header>
         <Modal.Body>
             Click "Yes" if you want to delete this commons. Click "No" if you don't want to delete this commons.       

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -5,8 +5,17 @@ import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtil
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
 
-export default function CommonsTable({ commons, currentUser }) {
+import { useState } from 'react';
+import Button from 'react-bootstrap/Button'
+import Modal from 'react-bootstrap/Modal'
 
+export default function CommonsTable({ commons, currentUser }) {
+    const [show, setShow] = useState(false);
+    const [cellDelete, setCellDelete] = useState(null);
+
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
+  
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
@@ -20,8 +29,33 @@ export default function CommonsTable({ commons, currentUser }) {
     );
 
     const deleteCallback = async (cell) => { 
-        deleteMutation.mutate(cell); 
+        setCellDelete(cell);
+        handleShow();
     }
+
+    const confirmDelete = async (cell) => {
+        deleteMutation.mutate(cell); 
+        handleClose();
+    }
+
+    const commonsTableModal = (
+    <Modal data-testid="CommonsTable-Modal" show={show} onHide={handleClose}>
+        <Modal.Header closeButton>
+            <Modal.Title>Commons Deletion Warning! </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+            Click "Yes" if you want to delete this commons. Click "No" if you don't want to delete this commons.       
+        </Modal.Body>
+        <Modal.Footer>
+            <Button variant="primary" data-testid="CommonsTable-Modal-YesDelete" onClick={() => confirmDelete(cellDelete)}>
+                Yes, delete this commons.
+            </Button>
+            <Button variant="secondary" data-testid="CommonsTable-Modal-NoDelete" onClick={() => setShow(false)}>
+                No, I don't want to delete this commons. 
+            </Button>
+        </Modal.Footer>
+    </Modal> 
+    );
 
     const leaderboardCallback = (cell) => {
         navigate(`/leaderboard/${cell.row.values["commons.id"]}`)
@@ -92,9 +126,14 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;
 
-    return <OurTable
-        data={commons}
-        columns={columnsToDisplay}
-        testid={testid}
-    />;
+    return (
+        <>
+            <OurTable
+                data={commons}
+                columns={columnsToDisplay}
+                testid={testid}
+            />
+            {hasRole(currentUser,"ROLE_ADMIN") && commonsTableModal}
+        </>
+    );
 };

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -101,14 +101,35 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`)).toHaveClass("btn-secondary");
   });
+});
 
-  test("the correct parameters are passed to useBackendMutation when Delete is clicked", async () => {
+describe("CommonsTable Modal tests", () => {
+  const queryClient = new QueryClient();
+  const mockMutate = jest.fn();
+  const mockUseBackendMutation = {
+    mutate: mockMutate,
+  };
 
+  beforeEach(() => { jest.spyOn(useBackendModule, "useBackendMutation").mockReturnValue(mockUseBackendMutation) });
+
+  afterEach(() => { jest.clearAllMocks() });
+  
+  test("Renders without crashing for empty table with user not logged in", () => {
+    const currentUser = null;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsTable commons={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("Clicking the delete button opens the modal for adminUser", async () => {
     const currentUser = currentUserFixtures.adminUser;
-
-
-    // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
-    const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -119,11 +140,37 @@ describe("UserTable tests", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button")).toBeInTheDocument();
+      expect(document.body).not.toHaveClass('modal-open');
     });
 
     const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
     fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(document.body).toHaveClass('modal-open');
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("Clicking yes in the modal popup deletes the commons", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsTable commons={commonsPlusFixtures.threeCommonsPlus} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+
+    const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
+    fireEvent.click(deleteButton);
+
+    const yesDeleteButton = await screen.findByTestId("CommonsTable-Modal-YesDelete");
+    fireEvent.click(yesDeleteButton);
 
     await waitFor(() => {
       expect(useBackendMutationSpy).toHaveBeenCalledWith(
@@ -133,6 +180,56 @@ describe("UserTable tests", () => {
       );
     });
 
+    await waitFor(() => { expect(document.body).not.toHaveClass('modal-open') });
   });
+
+  test("Clicking no in the modal popup deletes the commons", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsTable commons={commonsPlusFixtures.threeCommonsPlus} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
+    fireEvent.click(deleteButton);
+
+    const noDeleteButton = await screen.findByTestId("CommonsTable-Modal-NoDelete");
+    fireEvent.click(noDeleteButton);
+
+    await waitFor(() => { expect(document.body).not.toHaveClass('modal-open') });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("Pressing the escape key on the modal cancels the deletion", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+  
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsTable commons={commonsPlusFixtures.threeCommonsPlus} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  
+
+    const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
+    fireEvent.click(deleteButton);
+  
+    expect(document.body).toHaveClass('modal-open');
+  
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+  
+    await waitFor(() => { expect(document.body).not.toHaveClass('modal-open') });
+  
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+  
+  
 
 });

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -136,6 +136,11 @@ describe("AdminListCommonPage tests", () => {
         expect(deleteButton).toBeInTheDocument();
        
         fireEvent.click(deleteButton);
+        
+        const modalDelete = screen.getByTestId("CommonsTable-Modal-YesDelete");
+        await waitFor( () => { expect(modalDelete).toBeInTheDocument() });
+
+        fireEvent.click(modalDelete)
 
         await waitFor(() => { expect(mockToast).toBeCalledWith("Commons with id 1 was deleted") });
     });


### PR DESCRIPTION
## Overview
Clicking on the delete button in the commons editor now shows a modal popup instead of immediately deleting the commons. Tested the changes locally.

Screenshot of my changes:


## Tests
- [x] npm test
- [x] npm run coverage
- [] npx stryker run

Closes #7 