### PR TITLE
Add computeEffectiveCapacity and relvelent changes

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -281,10 +281,13 @@ public class CommonsController extends ApiController {
         Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
         Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
 
+        int effectiveCapacity = c.computeEffectiveCapacity();
+
         return CommonsPlus.builder()
                 .commons(c)
                 .totalCows(numCows.orElse(0))
                 .totalUsers(numUsers.orElse(0))
+                .effectiveCapacity(effectiveCapacity)
                 .build();
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -281,7 +281,7 @@ public class CommonsController extends ApiController {
         Optional<Integer> numCows = commonsRepository.getNumCows(c.getId());
         Optional<Integer> numUsers = commonsRepository.getNumUsers(c.getId());
 
-        int effectiveCapacity = c.computeEffectiveCapacity();
+        int effectiveCapacity = Commons.computeEffectiveCapacity(c,commonsRepository);
 
         return CommonsPlus.builder()
                 .commons(c)

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -3,6 +3,8 @@ package edu.ucsb.cs156.happiercows.entities;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +12,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -47,9 +52,10 @@ public class Commons {
     @JsonIgnore
     private List<UserCommons> joinedUsers;
 
-    @JsonGetter("effectiveCapacity")
-    public int computeEffectiveCapacity(){
-        int numUsers = (joinedUsers != null) ? joinedUsers.size():0;
-        return Math.max(capacityPerUser * numUsers, carryingCapacity);
+
+    public static int computeEffectiveCapacity(Commons commons, CommonsRepository commonsRepository) {
+        int numUsers = (commonsRepository.getNumUsers(commons.getId())).orElse(0);
+        return Math.max(commons.getCapacityPerUser() * numUsers, commons.getCarryingCapacity());
     }
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
@@ -45,4 +46,10 @@ public class Commons {
     @OneToMany(mappedBy = "commons", cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<UserCommons> joinedUsers;
+
+    @JsonGetter("effectiveCapacity")
+    public int computeEffectiveCapacity(){
+        int numUsers = (joinedUsers != null) ? joinedUsers.size():0;
+        return Math.max(capacityPerUser * numUsers, carryingCapacity);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
@@ -13,4 +13,5 @@ public class CommonsPlus {
     private Commons commons;
     private Integer totalCows;
     private Integer totalUsers;
+    private Integer effectiveCapacity;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CommonsPlus.java
@@ -1,6 +1,10 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.Builder;
@@ -10,8 +14,21 @@ import lombok.Builder;
 @NoArgsConstructor
 @Builder
 public class CommonsPlus {
+
     private Commons commons;
+    private CommonsRepository commonsRepository;
     private Integer totalCows;
     private Integer totalUsers;
     private Integer effectiveCapacity;
+
+    public CommonsPlus(Commons commons, CommonsRepository commonsRepository){
+        this.commons = commons;
+        this.commonsRepository = commonsRepository;
+        this.effectiveCapacity = Commons.computeEffectiveCapacity(commons, commonsRepository);
+    }
+    
+    @JsonGetter("effectiveCapacity")
+    public int getEffectiveCapacity(){
+        return this.effectiveCapacity;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -29,7 +29,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
-            ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", carryingCapacity: " + commons.getCarryingCapacity());
+            ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", effectiveCapacity: " + commons.computeEffectiveCapacity());
             int numUsers = commonsRepository.getNumUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumUsers(" + commons.getId() + ")"));
 
             if (numUsers==0) {
@@ -37,7 +37,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
                 continue;
             }
 
-            int carryingCapacity = commons.getCarryingCapacity();
+            int carryingCapacity = commons.computeEffectiveCapacity();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
             Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -19,13 +19,13 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
     Linear("Linear", "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            return user.getCowHealth() - (totalCows - commons.getCarryingCapacity()) * commons.getDegradationRate();
+            return user.getCowHealth() - (totalCows - commons.computeEffectiveCapacity()) * commons.getDegradationRate();
         }
     },
     Constant("Constant", "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
         @Override
         public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            if (totalCows <= commons.getCarryingCapacity()) {
+            if (totalCows <= commons.computeEffectiveCapacity()) {
                 return user.getCowHealth() + commons.getDegradationRate();
             } else {
                 return user.getCowHealth() - commons.getDegradationRate();

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategies.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.strategies;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -18,14 +19,14 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
 
     Linear("Linear", "Cow health increases/decreases proportionally to the number of cows over/under the carrying capacity.") {
         @Override
-        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            return user.getCowHealth() - (totalCows - commons.computeEffectiveCapacity()) * commons.getDegradationRate();
+        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows, CommonsRepository commonsRepository) {
+            return user.getCowHealth() - (totalCows - Commons.computeEffectiveCapacity(commons, commonsRepository)) * commons.getDegradationRate();
         }
     },
     Constant("Constant", "Cow health changes increases/decreases by the degradation rate, depending on if the number of cows exceeds the carrying capacity.") {
         @Override
-        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
-            if (totalCows <= commons.computeEffectiveCapacity()) {
+        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows, CommonsRepository commonsRepository) {
+            if (totalCows <= Commons.computeEffectiveCapacity(commons, commonsRepository)) {
                 return user.getCowHealth() + commons.getDegradationRate();
             } else {
                 return user.getCowHealth() - commons.getDegradationRate();
@@ -34,7 +35,7 @@ public enum CowHealthUpdateStrategies implements CowHealthUpdateStrategy {
     },
     Noop("Do nothing", "Cow health does not change.") {
         @Override
-        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows) {
+        public double calculateNewCowHealth(Commons commons, UserCommons user, int totalCows, CommonsRepository commonsRepository) {
             return user.getCowHealth();
         }
     };

--- a/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategy.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategy.java
@@ -2,13 +2,15 @@ package edu.ucsb.cs156.happiercows.strategies;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 
 public interface CowHealthUpdateStrategy {
 
     public double calculateNewCowHealth(
             Commons commons,
             UserCommons user,
-            int totalCows
+            int totalCows,
+            CommonsRepository commonsRepository
     );
 
     public String getDisplayName();

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.io.StringReader;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -619,14 +620,17 @@ public class CommonsControllerTests extends ControllerTestCase {
     @WithMockUser(roles = {"USER"})
     @Test
     public void getCommonsPlusByIdTest_valid() throws Exception {
+
         Commons Commons1 = Commons.builder()
                 .name("TestCommons2")
                 .id(18L)
+                .carryingCapacity(100)
                 .build();
         CommonsPlus commonsPlus = CommonsPlus.builder()
                 .commons(Commons1)
                 .totalCows(5)
                 .totalUsers(2)
+                .effectiveCapacity(100)
                 .build();
                 
         when(commonsRepository.findById(eq(18L))).thenReturn(Optional.of(Commons1));
@@ -891,7 +895,8 @@ public class CommonsControllerTests extends ControllerTestCase {
     @Test
     public void getCommonsPlusTest() throws Exception {
         List<Commons> expectedCommons = new ArrayList<>();
-        Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).build();
+
+        Commons Commons1 = Commons.builder().name("TestCommons1").id(1L).carryingCapacity(100).build();
         expectedCommons.add(Commons1);
 
         List<CommonsPlus> expectedCommonsPlus = new ArrayList<>();
@@ -899,7 +904,10 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .commons(Commons1)
                 .totalCows(50)
                 .totalUsers(20)
+                .effectiveCapacity(100)
                 .build();
+
+
 
         expectedCommonsPlus.add(CommonsPlus1);
         when(commonsRepository.findAll()).thenReturn(expectedCommons);

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsPlusTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsPlusTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -32,32 +33,15 @@ import java.util.Arrays;
 import java.util.Optional;
 
 @ExtendWith(SpringExtension.class)
-public class CommonsTest {
+public class CommonsPlusTest {
 
     @MockBean
     CommonsRepository commonsRepository;
 
-    User user1 = User
-            .builder()
-            .id(42L)
-            .fullName("Chris Gaucho")
-            .email("cgaucho@example.org")
-            .build();
-
     
-        UserCommons uc_1 = UserCommons
-            .builder()
-            .user(user1)
-            .username("Chris Gaucho")
-            .totalWealth(300)
-            .numOfCows(123)
-            .cowHealth(10)
-            .cowsBought(78)
-            .cowsSold(23)
-            .cowDeaths(6)
-            .build();
+    Commons commons;
 
-        Commons commons_1 = Commons
+    private Commons commons_1 = Commons
             .builder()
             .id(17L)
             .name("test commons 1")
@@ -70,25 +54,14 @@ public class CommonsTest {
             .degradationRate(0.01)
             .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
             .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
-            .joinedUsers(Arrays.asList(uc_1))
             .build();
-
+    
     @Test
-    void testComputeEffectiveCapacity_nousers(){
-        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.empty());
+    void testGetEffectiveCapacity(){
 
-        int res = Commons.computeEffectiveCapacity(commons_1, commonsRepository);
+        CommonsPlus commonsPlus = new CommonsPlus(commons_1, commonsRepository);
 
-        assertEquals(100, res);
-         
-      
-    }
-
-    @Test
-    void testComputeEffectiveCapacity(){
-         when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(5));
-         int res = Commons.computeEffectiveCapacity(commons_1, commonsRepository);
-         assertEquals(100, res);
+        assertEquals(100, commonsPlus.getEffectiveCapacity());
     }
     
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/entities/CommonsTest.java
@@ -1,0 +1,104 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommonsKey;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+public class CommonsTest {
+
+    @Test
+    void testComputeEffectiveCapacity_nousers(){
+        Commons commons_1 = Commons
+      .builder()
+      .id(17L)
+      .name("test commons 1")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+      .showLeaderboard(true)
+      .carryingCapacity(100)
+      .degradationRate(0.01)
+      .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .build();
+
+      assertEquals(100, commons_1.computeEffectiveCapacity());
+    }
+
+    @Test
+    void testComputeEffectiveCapacity(){
+         User user1 = User
+            .builder()
+            .id(42L)
+            .fullName("Chris Gaucho")
+            .email("cgaucho@example.org")
+            .build();
+
+    
+        UserCommons uc_1 = UserCommons
+            .builder()
+            .user(user1)
+            .username("Chris Gaucho")
+            .totalWealth(300)
+            .numOfCows(123)
+            .cowHealth(10)
+            .cowsBought(78)
+            .cowsSold(23)
+            .cowDeaths(6)
+            .build();
+
+        Commons commons_1 = Commons
+            .builder()
+            .id(17L)
+            .name("test commons 1")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+            .showLeaderboard(true)
+            .carryingCapacity(100)
+            .degradationRate(0.01)
+            .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+            .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+            .joinedUsers(Arrays.asList(uc_1))
+            .build();
+
+      
+
+
+        assertEquals(100, commons_1.computeEffectiveCapacity());
+    }
+    
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -53,6 +53,7 @@ public class UpdateCowHealthJobTests {
                         .milkPrice(2)
                         .startingBalance(300)
                         .startingDate(LocalDateTime.now())
+                        .capacityPerUser(0)
                         .carryingCapacity(100)
                         .degradationRate(1)
                         .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
@@ -107,7 +108,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 9.0
                                 Cow health has been updated!""";
@@ -125,7 +126,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 Cow health has been updated!""";
@@ -144,7 +145,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 Cow health has been updated!""";
@@ -199,7 +200,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 1, cowHealth: 10.0
                                  old cow health: 10.0, new cow health: 11.0
                                 User: Chris Gaucho, numCows: 6, cowHealth: 20.0
@@ -279,7 +280,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 User: Chris Gaucho, numCows: 5, cowHealth: -1.0
                                  5 cows for this user died.
                                  old cow health: -1.0, new cow health: 100.0
@@ -304,7 +305,7 @@ public class UpdateCowHealthJobTests {
 
                 String expected = """
                                 Updating cow health...
-                                Commons test commons, degradationRate: 1.0, carryingCapacity: 100
+                                Commons test commons, degradationRate: 1.0, effectiveCapacity: 100
                                 No users in this commons, skipping
                                 Cow health has been updated!""";
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -155,24 +155,26 @@ public class UpdateCowHealthJobTests {
         @Test
         void test_cow_health_minimum_is_0() throws Exception {
                 var mockStrategy = mock(CowHealthUpdateStrategy.class);
-                when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt())).thenReturn(-1.0);
+                when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt(), any())).thenReturn(-1.0);
                 var newHealth = UpdateCowHealthJob.calculateNewCowHealthUsingStrategy(
                                 mockStrategy,
                                 commons,
                                 userCommons,
-                                1);
+                                1,
+                                commonsRepository);
                 assertEquals(0.0, newHealth);
         }
 
         @Test
         void test_cow_health_maximum_is_100() throws Exception {
                 var mockStrategy = mock(CowHealthUpdateStrategy.class);
-                when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt())).thenReturn(101.0);
+                when(mockStrategy.calculateNewCowHealth(any(), any(), anyInt(), any())).thenReturn(101.0);
                 var newHealth = UpdateCowHealthJob.calculateNewCowHealthUsingStrategy(
                                 mockStrategy,
                                 commons,
                                 userCommons,
-                                1);
+                                1,
+                                commonsRepository);
                 assertEquals(100.0, newHealth);
         }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/strategies/CowHealthUpdateStrategyTests.java
@@ -2,12 +2,23 @@ package edu.ucsb.cs156.happiercows.strategies;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
 class CowHealthUpdateStrategyTests {
+
+    @MockBean
+    CommonsRepository commonsRepository;
 
     @Test
     void get_name_and_description() {
@@ -18,6 +29,7 @@ class CowHealthUpdateStrategyTests {
 
 
     Commons commons = Commons.builder()
+            .id(17L)
             .degradationRate(0.01)
             .carryingCapacity(100)
             .build();
@@ -27,27 +39,33 @@ class CowHealthUpdateStrategyTests {
     void linear_updates_health_proportional_to_num_cows_over_capacity() {
         var formula = CowHealthUpdateStrategies.Linear;
 
-        assertEquals(49.9, formula.calculateNewCowHealth(commons, user, 110));
-        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 100));
-        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 90));
+        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(1));
+
+        assertEquals(49.9, formula.calculateNewCowHealth(commons, user, 110, commonsRepository));
+        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 100, commonsRepository));
+        assertEquals(50.1, formula.calculateNewCowHealth(commons, user, 90, commonsRepository));
     }
 
     @Test
     void constant_changes_by_constant_amount() {
         var formula = CowHealthUpdateStrategies.Constant;
 
-        assertEquals(49.99, formula.calculateNewCowHealth(commons, user, 120));
-        assertEquals(49.99, formula.calculateNewCowHealth(commons, user, 110));
-        assertEquals(50.01, formula.calculateNewCowHealth(commons, user, 100));
-        assertEquals(50.01, formula.calculateNewCowHealth(commons, user, 90));
+        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(1));
+
+        assertEquals(49.99, formula.calculateNewCowHealth(commons, user, 120, commonsRepository));
+        assertEquals(49.99, formula.calculateNewCowHealth(commons, user, 110, commonsRepository));
+        assertEquals(50.01, formula.calculateNewCowHealth(commons, user, 100, commonsRepository));
+        assertEquals(50.01, formula.calculateNewCowHealth(commons, user, 90, commonsRepository));
     }
 
     @Test
     void noop_does_nothing() {
         var formula = CowHealthUpdateStrategies.Noop;
 
-        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 110));
-        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 100));
-        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 90));
+        when(commonsRepository.getNumUsers(17L)).thenReturn(Optional.of(1));
+
+        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 110, commonsRepository));
+        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 100, commonsRepository));
+        assertEquals(50.0, formula.calculateNewCowHealth(commons, user, 90, commonsRepository));
     }
 }


### PR DESCRIPTION
## Overview
For this pr, 
1. I added `computeEffectiveCapacity()`method
2. Made changes in revelent files
3. Changed `CommonsPlus` object

<img width="328" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/85e97750-5c01-487a-81f9-2704c2767f30">

<img width="806" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/3e99ce25-4010-43ff-bc02-514aa1f5ea93">

## Test
- [x] `mvn test`
- [x] `mvn test jacoco:report`
- [x] `mvn test org.pitest:pitest-maven:mutationCoverage`

Revelent changes for #13 
