### PR TITLE
[Andrew] Fixed Degradation Rate Steps to 0.001

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -163,7 +163,7 @@ function CommonsForm({ initialCommons, submitAction, buttonLabel = "Create" }) {
                         data-testid={`${testid}-degradationRate`}
                         id="degradationRate"
                         type="number"
-                        step="0.01"
+                        step="0.001"
                         defaultValue={defaultValues.degradationRate}
                         isInvalid={!!errors.degradationRate}
                         {...register("degradationRate", {


### PR DESCRIPTION
In this PR, I changed the degradation rate step to 0.001.

<img width="733" alt="Screenshot 2023-08-26 at 10 30 32 AM" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/46334533/7347d488-3d39-4b1f-a271-343b7dd691e3">

## Tests
- [x] `npm test`
- [x] `npm run coverage`
- [x] `npx stryker run -m src/main/components/Commons/CommonsForm.js`

Closes #14 

## Disclaimer
This is an exact copy of Ryan's first PR. Merge with 0 point value.