### PR TITLE
List commons shows capacityPerUser and effectiveCapacity

### DIFF
--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -12,9 +12,11 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": false,
                 "carryingCapacity": 100,
+                "capacityPerUser": 25
             },
             "totalCows": 10,
-            "totalUsers": 2
+            "totalUsers": 2,
+            "effectiveCapacity": 100
         },
         {
             "commons":
@@ -29,9 +31,11 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": true,
                 "carryingCapacity": 42,
+                "capacityPerUser": 20
             },
             "totalCows": 0,
-            "totalUsers": 1
+            "totalUsers": 1,
+            "effectiveCapacity": 42
         },
         {
             "commons":
@@ -46,9 +50,11 @@ const commonsPlusFixtures = {
                 "degradationRate": 5.0,
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
+                "capacityPerUser": 150
             },
             "totalCows": 0,
-            "totalUsers": 1
+            "totalUsers": 1,
+            "effectiveCapacity": 150
         },
 
     ],

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -112,6 +112,15 @@ export default function CommonsTable({ commons, currentUser }) {
             Header: 'Carrying Capacity',
             accessor: row => row.commons.carryingCapacity,
             id: 'commons.carryingCapacity'
+        },
+        {
+            Header: 'Capacity Per User',
+            accessor: row => row.commons.capacityPerUser,
+            id: 'commons.capacityPerUser'
+        },
+        {
+            Header: 'Effective Capacity',
+            accessor: 'effectiveCapacity'
         }
     ];
 

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -76,8 +76,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Cows', 'Show Leaderboard?'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Capacity Per User', 'Effective Capacity', 'Cows', 'Show Leaderboard?'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity", "capacityPerUser"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -99,10 +99,12 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.milkPrice`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.degradationRate`)).toHaveTextContent("0.01");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.carryingCapacity`)).toHaveTextContent("42");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.capacityPerUser`)).toHaveTextContent("20")
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingBalance`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingDate`)).toHaveTextContent(/^2022-11-22$/); // regex so that we have an exact match https://stackoverflow.com/a/73298371
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.showLeaderboard`)).toHaveTextContent("true");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCows`)).toHaveTextContent("0");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-effectiveCapacity`)).toHaveTextContent("42");
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`)).toHaveClass("btn-primary");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
@@ -122,6 +124,8 @@ describe("CommonsTable Modal tests", () => {
 
   afterEach(() => { jest.clearAllMocks() });
   
+  const testId = "CommonsTable";
+
   test("Renders without crashing for empty table with user not logged in", () => {
     const currentUser = null;
 
@@ -151,6 +155,7 @@ describe("CommonsTable Modal tests", () => {
       expect(document.body).not.toHaveClass('modal-open');
     });
 
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
     fireEvent.click(deleteButton);
 
@@ -173,7 +178,7 @@ describe("CommonsTable Modal tests", () => {
       </QueryClientProvider>
     );
 
-
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
     fireEvent.click(deleteButton);
 
@@ -191,7 +196,7 @@ describe("CommonsTable Modal tests", () => {
     await waitFor(() => { expect(document.body).not.toHaveClass('modal-open') });
   });
 
-  test("Clicking no in the modal popup deletes the commons", async () => {
+  test("Clicking no in the modal popup does not delete the commons", async () => {
     const currentUser = currentUserFixtures.adminUser;
 
     render(
@@ -202,6 +207,7 @@ describe("CommonsTable Modal tests", () => {
       </QueryClientProvider>
     );
 
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
     fireEvent.click(deleteButton);
 
@@ -224,7 +230,7 @@ describe("CommonsTable Modal tests", () => {
       </QueryClientProvider>
     );
   
-
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     const deleteButton = screen.getByTestId("CommonsTable-cell-row-0-col-Delete-button");
     fireEvent.click(deleteButton);
   


### PR DESCRIPTION
## Overview
In this PR, I added the capacityPerUser and effectiveCapacity in the List Commons Table

<img width="875" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-3/assets/58492076/4c7b099f-a9c6-4ecd-ae68-4f2f49a80b88">

## Tests
- [x] npm test
- [x] npm run coverage
- [x] npx stryker run -m "src/main/components/Commons/CommonsTable.js"